### PR TITLE
Add anchor links; Cut out script as js file

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,4 +18,5 @@
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="msapplication-config" content="{{ "/" | absolute_url }}/assets/images/favicons/browserconfig.xml?v=m2LbYGrvJB">
   <meta name="theme-color" content="#ffffff">
+  <script src="https://cdn.jsdelivr.net/npm/anchor-js/anchor.min.js"></script>
 </head>

--- a/_layouts/content-base.html
+++ b/_layouts/content-base.html
@@ -7,7 +7,7 @@
         {% assign current_collection = site.collections | where: "label", page.collection | first %}
         <div class="center">
           {% include logo-title.html %}
-          <h3><a href="{{ "/" | absolute_url }}{{ page.collection }}">for {{ current_collection.version }}</a></h3>
+          <h3 class="no-anchor"><a href="{{ "/" | absolute_url }}{{ page.collection }}">for {{ current_collection.version }}</a></h3>
         </div>
         <div id="navcontainer">
           {% include navigation.html max_depth=3 selected_docs=current_collection.docs %}
@@ -32,36 +32,10 @@
     </div>
     {% include google-analytics.html %}
   </body>
-
+  <script type="text/javascript" src="{{ "/" | absolute_url }}/assets/js/getLastUpdateDate.js"></script>
+  <script type="text/javascript" src="{{ "/" | absolute_url }}/assets/js/addAnchorLinkToHeader.js"></script>
   <script>
 
-    const url = "{{ site.github.api_url }}/repos/{{ site.github.owner_name }}/{{ site.github.repository_name }}/commits?path={{ site.collections_dir }}%2F{{ page_path }}&page=1&per_page=1"
-    let request = new XMLHttpRequest();
- 
-    request.open('GET', url, true);
-    request.responseType = 'json';
 
-    request.onload = function () {
-      let utcDatetime = this.response[0].commit.committer.date;
-      let localDatetime = dateFormat.format(new Date(utcDatetime), "yyyy-MM-dd hh:mm:ss");
-      document.getElementById("last_update_datetime").innerText = "Last update: " + localDatetime;
-
-    };
-    request.send();
- 
-    dateFormat = {
-      _fmt : {
-        "yyyy": function(date) { return date.getFullYear() + ''; },
-        "MM": function(date) { return ('0' + (date.getMonth() + 1)).slice(-2); },
-        "dd": function(date) { return ('0' + date.getDate()).slice(-2); },
-        "hh": function(date) { return ('0' + date.getHours()).slice(-2); },
-        "mm": function(date) { return ('0' + date.getMinutes()).slice(-2); },
-        "ss": function(date) { return ('0' + date.getSeconds()).slice(-2); }
-      },
-      _priority : ["yyyy", "MM", "dd", "hh", "mm", "ss"],
-      format: function(date, format){
-        return this._priority.reduce((res, fmt) => res.replace(fmt, this._fmt[fmt](date)), format)
-      }
-    };
   </script>
 </html>

--- a/assets/js/addAnchorLinkToHeader.js
+++ b/assets/js/addAnchorLinkToHeader.js
@@ -1,0 +1,7 @@
+
+/*
+In order to add deep anchor links to existing page content, using "AnchorJS".
+https://github.com/bryanbraun/anchorjs
+*/
+anchors.options.placement = "left"
+anchors.add('h3:not(.no-anchor)');

--- a/assets/js/getLastUpdateDate.js
+++ b/assets/js/getLastUpdateDate.js
@@ -1,0 +1,31 @@
+---
+---
+
+const url = "{{ site.github.api_url }}/repos/{{ site.github.owner_name }}/{{ site.github.repository_name }}/commits?path={{ site.collections_dir }}%2F{{ page_path }}&page=1&per_page=1"
+let request = new XMLHttpRequest();
+
+request.open('GET', url, true);
+request.responseType = 'json';
+
+request.onload = function () {
+  let utcDatetime = this.response[0].commit.committer.date;
+  let localDatetime = dateFormat.format(new Date(utcDatetime), "yyyy-MM-dd hh:mm:ss");
+  document.getElementById("last_update_datetime").innerText = "Last update: " + localDatetime;
+
+};
+request.send();
+
+dateFormat = {
+  _fmt : {
+    "yyyy": function(date) { return date.getFullYear() + ''; },
+    "MM": function(date) { return ('0' + (date.getMonth() + 1)).slice(-2); },
+    "dd": function(date) { return ('0' + date.getDate()).slice(-2); },
+    "hh": function(date) { return ('0' + date.getHours()).slice(-2); },
+    "mm": function(date) { return ('0' + date.getMinutes()).slice(-2); },
+    "ss": function(date) { return ('0' + date.getSeconds()).slice(-2); }
+  },
+  _priority : ["yyyy", "MM", "dd", "hh", "mm", "ss"],
+  format: function(date, format){
+    return this._priority.reduce((res, fmt) => res.replace(fmt, this._fmt[fmt](date)), format)
+  }
+};


### PR DESCRIPTION
This PR has 2 changes.

### 1. Add anchor links
In order to respond to this request(https://github.com/msagansk/Augur.Guide/issues/8), I added anchor links on all pages by using [AnchorJS](https://github.com/bryanbraun/anchorjs). However, the link icon appeared on the versioning label by implementing it. ↓
![20201102_anchorLink1](https://user-images.githubusercontent.com/38453357/98056604-a607a500-1e83-11eb-9635-ba4203493726.png)

To removed this icon, I did the following 2 things.
1. I added the class `no-anchor` to the versioning label tag.
https://github.com/CrystalBallBe/Augur.Guide/blob/d88a51cb58cda81e96c2e8a3aca210f625aa0345/_layouts/content-base.html#L10
2. I set AnchorJS not to give anchor links to that class.
https://github.com/CrystalBallBe/Augur.Guide/blob/d88a51cb58cda81e96c2e8a3aca210f625aa0345/assets/js/addAnchorLinkToHeader.js#L7

I did this chage based on [this doc](https://www.bryanbraun.com/anchorjs/#removing-anchors).
### 2. Cut out javascript as `xxx.js` file
Javascript was written in the source tag of `root/_layouts/content-base.html`, but I cut out the source by function as files and stored those files under `root/assets/js/`.
