### PR TITLE
Update whitepaper-v1 URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,11 +12,13 @@ collections:
     top-page: true
     version: "version1"
     language: "English"
+    whitepaper-pdf-url: "https://github.com/AugurProject/whitepaper/blob/master/v1/english/whitepaper.pdf"
   version2-english:
     output: true
     top-page: true
     version: "version2"
     language: "English"
+    whitepaper-pdf-url: "https://github.com/AugurProject/whitepaper/blob/master/v2/english/augur-whitepaper-v2.pdf"
 defaults:
   -
     scope:

--- a/collections/_version1-english/1-getting-started.md
+++ b/collections/_version1-english/1-getting-started.md
@@ -1,6 +1,7 @@
 ---
 title: Getting Started
 ---
+{% assign current_collection = site.collections | where: "label", page.collection | first %}
 # Getting Started
 
 ### What is Augur Anyway?
@@ -16,7 +17,7 @@ Augur usage centers around a collection of [markets]({{ "/" | absolute_url }}/{{
 
 A trader can escrow a quantity of [ETH]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#ETH) (will change to the stablecoin DAI in the next version of Augur) on a potential outcome of that event and its estimated probability, which is tracked on an [order book]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#Order_Book). The order book for Augur is managed on-chain by Ethereum contracts. When two opposing orders are matched (typically by two traders who take opposing views on the likely outcome of the market), the ETH is exchanged for [SHARES]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#SHARE) (an ERC20 token). Depending on the final outcome of the market, traders exchange the SHARES back for more ETH than they started with, or less.
 
-Markets go through a series of states, which we'll get into later. Official documentation on the nitty gritty is available on the [Augur Whitepaper](https://www.augur.net/whitepaper.pdf) or the [Developer Docs](https://docs.augur.net). One important thing to realize is that **trading never stops**, even after the event has happened. Sometime after the event has happened, the market will enter the [reporting phase]({{ "/" | absolute_url }}/{{page.collection}}/4-reporters/1-reporting-process.html). This is when the winning outcome is decided. Fortunately, you don’t have to trust one party to correctly resolve the market. Augur’s reporters ([REP]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#REP) holders) can [dispute]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#Dispute) markets that they believe have been resolved incorrectly. This may take some extra time before winning SHARES can be claimed, but it makes the platform robust and secure through its decentralization.
+Markets go through a series of states, which we'll get into later. Official documentation on the nitty gritty is available on the [Augur Whitepaper]({{current_collection.whitepaper-pdf-url}}) or the [Developer Docs](https://docs.augur.net). One important thing to realize is that **trading never stops**, even after the event has happened. Sometime after the event has happened, the market will enter the [reporting phase]({{ "/" | absolute_url }}/{{page.collection}}/4-reporters/1-reporting-process.html). This is when the winning outcome is decided. Fortunately, you don’t have to trust one party to correctly resolve the market. Augur’s reporters ([REP]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#REP) holders) can [dispute]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#Dispute) markets that they believe have been resolved incorrectly. This may take some extra time before winning SHARES can be claimed, but it makes the platform robust and secure through its decentralization.
 
 ### What Interests You?
 

--- a/collections/_version1-english/2-market-creators/examples.md
+++ b/collections/_version1-english/2-market-creators/examples.md
@@ -1,6 +1,7 @@
 ---
 title: Examples
 ---
+{% assign current_collection = site.collections | where: "label", page.collection | first %}
 # Market Creators: Examples
 
 Here are a few examples of different markets that have been created in the past that are worded well to help ensure validity and clarity for traders and reporters. You can use these as templates to help you get started creating your own markets that are well crafted.
@@ -41,7 +42,7 @@ A [resolution source]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.ht
 
 **Notes:** Politics markets are also one of the easiest categories to make valid markets for, but a little harder than sports markets. The additional details for the market really need to spell out as many of the edge cases as possible, so knowledge of the political system the market is about is crucial. In addition, the market end time typically needs to be *well* after you expect the event to occur, because large delays are possible (ex. election results). This particular market’s end time is over a month after the expected election date. That being said, a resolution source won’t be needed (general knowledge is fine) because election results tend to not have any ambiguity once the answer is determined.
 
-In addition, for long running markets such as this one, additional risk factors start to come into play. Augur’s current design doesn’t make it well suited for markets that go out further than 6 months. One reason is that Augur expects to do contract upgrades which involves migrating [REP]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#REP) from one version to another, potentially leaving markets behind with not enough honest REP holders to report the correct result. The other reason is that long running markets potentially don’t end up paying a “fair” amount of reporting fees based on how long Augur is required to ensure the security of the market. This gets into complex game-theory topics that we won’t dive into here, see the [Augur Whitepaper](https://www.augur.net/whitepaper.pdf) for more details.
+In addition, for long running markets such as this one, additional risk factors start to come into play. Augur’s current design doesn’t make it well suited for markets that go out further than 6 months. One reason is that Augur expects to do contract upgrades which involves migrating [REP]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#REP) from one version to another, potentially leaving markets behind with not enough honest REP holders to report the correct result. The other reason is that long running markets potentially don’t end up paying a “fair” amount of reporting fees based on how long Augur is required to ensure the security of the market. This gets into complex game-theory topics that we won’t dive into here, see the [Augur Whitepaper]({{current_collection.whitepaper-pdf-url}}) for more details.
 
 ### Cryptocurrency
 

--- a/collections/_version1-english/4-reporters.md
+++ b/collections/_version1-english/4-reporters.md
@@ -1,6 +1,7 @@
 ---
 title: Reporters
 ---
+{% assign current_collection = site.collections | where: "label", page.collection | first %}
 # Reporters 
 
 Reporters are people who own Augur’s token, [REP]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#REP). Decentralized REP holders have the power to affect the final [outcome]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#Outcome) of Augur’s [markets]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#Market). This is very different from a typical prediction market where the reporting source is a centralized body, usually a company running the prediction market. Augur’s reporters have a job to oversee the [initial report]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#Initial_Report) of a market and ensure it is the correct answer. For doing this work REP holders are rewarded with [ETH]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#ETH), collected as [reporting fees]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#Reporting_Fee).
@@ -27,11 +28,11 @@ Every market has [Invalid]({{ "/" | absolute_url }}/{{page.collection}}/7-glossa
 
 ### Can [whales](https://en.wikipedia.org/wiki/High_roller) just bully markets the way they want them to resolve?
 
-Reporting isn't a [game of chicken](https://en.wikipedia.org/wiki/Chicken_(game)). Augur has fairly complicated game-theory for how the reporting process works, but it essentially revolves around traders and reporters using truth as a sort of [schelling point](https://en.wikipedia.org/wiki/Focal_point_(game_theory)). Additional details as to why can be found in the [Augur Whitepaper](https://www.augur.net/whitepaper.pdf).
+Reporting isn't a [game of chicken](https://en.wikipedia.org/wiki/Chicken_(game)). Augur has fairly complicated game-theory for how the reporting process works, but it essentially revolves around traders and reporters using truth as a sort of [schelling point](https://en.wikipedia.org/wiki/Focal_point_(game_theory)). Additional details as to why can be found in the [Augur Whitepaper]({{current_collection.whitepaper-pdf-url}}).
 
 ### How does the reporting fee get set?
 
-The [reporting fee]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#Reporting_Fee) is a percentage that is adjusted weekly. It is adjusted upwards (33% ceiling) to apply upwards pressure on the price of REP if it is too low. It is adjusted downwards if the price of REP is too high, to a floor of 0.01%. What determines what is too high or low? Well, we want to ensure that REP is valuable enough such that it costs more to attack the reporting process than what can be gained out of trading ETH on markets. This security model is detailed in the [Augur whitepaper](https://www.augur.net/whitepaper.pdf).
+The [reporting fee]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#Reporting_Fee) is a percentage that is adjusted weekly. It is adjusted upwards (33% ceiling) to apply upwards pressure on the price of REP if it is too low. It is adjusted downwards if the price of REP is too high, to a floor of 0.01%. What determines what is too high or low? Well, we want to ensure that REP is valuable enough such that it costs more to attack the reporting process than what can be gained out of trading ETH on markets. This security model is detailed in the [Augur whitepaper]({{current_collection.whitepaper-pdf-url}}).
 
 ### How do I collect my reporting fees?
 

--- a/collections/_version1-english/4-reporters/3-forks.md
+++ b/collections/_version1-english/4-reporters/3-forks.md
@@ -1,10 +1,10 @@
 ---
 title: Forks
 ---
-
+{% assign current_collection = site.collections | where: "label", page.collection | first %}
 # Reporters: Forks
 
-This page is adapted from the [Augur Whitepaper](https://www.augur.net/whitepaper.pdf) due to its highly technical nature. The intricate details are most important to understand as a [REP]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#REP) reporter, although everyone who participates in Augur may be affected by it at some point.
+This page is adapted from the [Augur Whitepaper]({{current_collection.whitepaper-pdf-url}}) due to its highly technical nature. The intricate details are most important to understand as a [REP]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#REP) reporter, although everyone who participates in Augur may be affected by it at some point.
 
 The fork state is a special state that can last up to 60 days.  Forking is the [market]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#Market) resolution method of last resort; it is a very disruptive process and is intended to be a rare occurrence. This market is referred to as the [forking market]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#Forked_Market), as it has implications for the other markets that currently exist. When a fork is initiated, [disputing]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#Dispute) for all other non-resolved markets is put on hold until this fork resolves.  The [forking period]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#Fork_Period) is much longer than the usual [fee window]({{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html#Fee_Window) because the platform needs to provide ample time for REP holders and service providers (such as wallets and exchanges) to prepare.  A fork’s final outcome cannot be disputed. 
 


### PR DESCRIPTION
In the content files for version1, the link to the whitepaper were `https://www.augur.net/whitepaper.pdf`. However, if you jump to that URL now, you will see the for version 2. So I changed the URL to github(https://github.com/AugurProject/whitepaper/blob/master/v1/english/whitepaper.pdf).

And contents for version2 also requires a link to the whitepaper, so I used the URL https://github.com/AugurProject/whitepaper/blob/master/v2/english/augur-whitepaper-v2.pdf.

These URL are set in the configuration file `_config.yml` as key `collections.versionX-english.whitepaper-pdf-url`.