### PR TITLE
Add border and header-color to all tables

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -108,6 +108,9 @@ th,
 td {
 	text-align: left;
 	padding: 2px 2px;
+	border-right: 1px solid #e5e5e5;
+	border-left: 1px solid #e5e5e5;
+	border-top: 1px solid #e5e5e5;
 	border-bottom: 1px solid #e5e5e5
 }
 
@@ -117,7 +120,8 @@ dt {
 }
 
 th {
-	color: #444
+	background-color: #55357E;
+	color: #fff;
 }
 
 img {

--- a/assets/js/augur-ui/htmlElementCreators/tableAugurUiOnENS.js
+++ b/assets/js/augur-ui/htmlElementCreators/tableAugurUiOnENS.js
@@ -72,10 +72,7 @@ export function create(param) {
   }
 }
 function createTableRow(tbody, headerName, url, text, addedText = "") {
-  const WhiteSpace = "\u00A0\u00A0\u00A0\u00A0";
-
   let tr = document.createElement("tr");
-  tr.appendChild(BaseElements.td(WhiteSpace));
   tr.appendChild(BaseElements.td(headerName));
   tr.appendChild(BaseElements.tdTextLink(url, text, addedText));
   tbody.appendChild(tr);

--- a/assets/js/augur-ui/htmlElementCreators/tableQuickAccess.js
+++ b/assets/js/augur-ui/htmlElementCreators/tableQuickAccess.js
@@ -50,7 +50,6 @@ export function create(arrEnsDomainData) {
           Url.getUrlGithubRelease(ensDomainData.tagName),
           ensDomainData.tagName,
           " (for " + ensDomainData.use + ")",
-          "",
           "center"
         )
       );


### PR DESCRIPTION
To make tables easy to see, I added border and background-color of header to all tables.
And I made miner adjustments to the tables `Quick way to access Augur UI` and `augur2.eth`.