### PR TITLE
Reflect the suggestions on PR#34 No.2

### DIFF
--- a/collections/_version2-english/9-fork/2-to-dos.md
+++ b/collections/_version2-english/9-fork/2-to-dos.md
@@ -24,7 +24,7 @@ title: To-do's
 If you are a REP holder, there are some things you **MUST** do for a [fork]({{glossary_fork}}) to not lose your [REP]({{glossary_reputation_token}}).
 
 ## Before a fork starts
-REP holders have a thing to do even before a [fork]({{glossary_fork}}) starts so that they don't lose the value of their [REP]({{glossary_reputation_token}}). That is to **check monthly to see if a fork occurs**.
+Before a [fork]({{glossary_fork}}) starts, REP holders still have to be actively involved so that they don't lose the value of their [REP]({{glossary_reputation_token}}). The minimum involvement necessary to avoid permanent losses of REP is to **check monthly to see if a fork occurs**.
 
 [Forks]({{glossary_fork}}) last for 60 days, so it is strongly recommended that all REP holders "check in" on the project at least once a month to make sure that no fork is underway or they risk losing all of their REP.
 

--- a/collections/_version2-english/9-fork/2-to-dos.md
+++ b/collections/_version2-english/9-fork/2-to-dos.md
@@ -3,9 +3,9 @@ title: To-do's
 ---
 {% capture glossary_path %}{{ "/" | absolute_url }}/{{page.collection}}/7-glossary.html{% endcapture %}
 {% assign glossary_child_universe = glossary_path | append: '#Child_Universe' %}
+{% assign glossary_dispute = glossary_path | append: '#Dispute' %}
 {% assign glossary_final_outcome = glossary_path | append: '#Final_Outcome' %}
 {% assign glossary_finalized_market = glossary_path | append: '#Finalized_Market' %}
-
 {% assign glossary_fork = glossary_path | append: '#Fork' %}
 {% assign glossary_forking_market = glossary_path | append: '#Forking_Market' %}
 {% assign glossary_forking_period = glossary_path | append: '#Forking_Period' %}
@@ -24,12 +24,22 @@ title: To-do's
 If you are a REP holder, there are some things you **MUST** do for a [fork]({{glossary_fork}}) to not lose your [REP]({{glossary_reputation_token}}).
 
 ## Before a fork starts
-REP holders have 2 things to do even before a [fork]({{glossary_fork}}) starts so that they don't lose the value of their [REP]({{glossary_reputation_token}}). One is to [convert REPv1 to REPv2](#convert-repv1-to-repv2) and the other is to [check monthly to see if a fork occurs](#check-monthly-to-see-if-a-fork-occurs).
+REP holders have a thing to do even before a [fork]({{glossary_fork}}) starts so that they don't lose the value of their [REP]({{glossary_reputation_token}}). That is to **check monthly to see if a fork occurs**.
 
-### Convert REPv1 to REPv2
-REPv1 holders **MUST** convert their [REPv1]({{glossary_repv1}}) to [REPv2]({{glossary_repv2}}), because REP in the [parent universe]({{glossary_parent_universe}}) can be migrated to only its [child universe]({{glossary_child_universe}}) and once the fork is complete migration into a child universe is no longer possible!
+[Forks]({{glossary_fork}}) last for 60 days, so it is strongly recommended that all REP holders "check in" on the project at least once a month to make sure that no fork is underway or they risk losing all of their REP.
 
-That means they have to follow the chain of [universes]({{glossary_universe}}). For example, [forks]({{glossary_fork}}) occur in the following order:
+The process of "checking in" just means open the [Augur UI]({{ "/" | absolute_url }}/{{page.collection}}/8-augur-ui.html) or ask around (Discord, Twitter, Reddit, etc.) and see if a fork is underway. If no fork is underway then you can go back to passively holding for a month until your next check in without risk of losing your REP.
+
+Useful links for checking if a fork occurs are:
+ - [Augur Discord server](https://invite.augur.net)  ⭐*recommended*⭐
+ - The [official Twitter account](https://twitter.com/augurproject)
+ - The [official blog](https://augur.net/blog)
+ - The subreddit [/r/Augur](https://www.reddit.com/r/Augur/)
+
+## By the end of a fork
+[REPv1]({{glossary_repv1}}) holders **MUST** convert their REPv1 to [REPv2]({{glossary_repv2}}) before 60 days have passed since the [fork]({{glossary_fork}}) started, because [REP]({{glossary_reputation_token}}) in the [parent universe]({{glossary_parent_universe}}) can be migrated to only its [child universe]({{glossary_child_universe}}) and once the fork is complete migration into a child universe is no longer possible!
+
+That means they have to follow the chain of [universes]({{glossary_universe}}). For example, forks occur in the following order:
 ```
 universe A → universe B → universe C
 ```
@@ -41,17 +51,6 @@ It cannot skip `universe B`.
 {% capture image_src %}{{ "/" | absolute_url }}assets/images/{{page.collection}}/fork/to-dos/chain-of-universes.svg{% endcapture %}
 {% include zoom-image.html src=image_src caption="Figure 1. chain of universes" %}
 
-### Check monthly to see if a fork occurs
-[Forks]({{glossary_fork}}) last for 60 days, so it is strongly recommended that all REP holders "check in" on the project at least once a month to make sure that no fork is underway or they risk losing all of their REP.
-
-The process of "checking in" just means open the [Augur UI]({{ "/" | absolute_url }}/{{page.collection}}/8-augur-ui.html) or ask around (Discord, Twitter, Reddit, etc.) and see if a fork is underway. If no fork is underway then you can go back to passively holding for a month until your next check in without risk of losing your REP.
-
-Useful links for checking if a fork occurs are:
- - [Augur Discord server](https://invite.augur.net)  ⭐*recommended*⭐
- - The [official Twitter account](https://twitter.com/augurproject)
- - The [official blog](https://augur.net/blog)
- - The subreddit [/r/Augur](https://www.reddit.com/r/Augur/)
-
 ## After starting a fork (60 days)
 REP holders needs to pick a side and migrate their REP to the [child universe]({{glossary_child_universe}}) they believe aligns with reality within 60 days from starting a [fork]({{glossary_fork}}).
 
@@ -59,13 +58,10 @@ After 60 days from starting a fork, [REP]({{glossary_reputation_token}}) in the 
 
 However, the choice should be considered carefully, because migration is one-way; it cannot be reversed. REP cannot be sent from one [sibling universe]({{glossary_sibling_universe}}]) to another.
 
-### What if REP holders don't wish to join in the fork?
+## What if REP holders don't wish to join in the fork?
 They may sell their [REP]({{glossary_reputation_token}}) before the [fork]({{glossary_fork}}) is over, but beware that if many people exercise this strategy the price of REP may drop leading up to the fork and then rebound in the [truth universe]({{glossary_truth_universe}}) after the fork, this could be a costly strategy.
 
-### You receive 40% ROI by joining in the fork?
-Wether you receive 40% [ROI]({{glossary_roi}}) on your migrated [REP]({{glossary_reputation_token}}) by joining in the [fork]({{glossary_fork}}) depends on when and where you migrate your REP. If you migrate your REP during the [forking period]({{glossary_forking_period}}) and the [child universe]({{glossary_child_universe}}) which you migrate it becomes [*winning universe*]({{glossary_winning_universe}}) , then you get 40% ROI on your migrated REP. If you migrate after the forking period, you may not get 40% ROI but you can migrate it without risk of migrating to [*losing universe*]({{glossary_losing_universe}}). Because the [final outcome]({{glossary_final_outcome}}) of the [forking market]({{glossary_forking_market}}) is fixed when the forking period ends.
+## Is there any reward for migrating REP to a child universe?
+No. If you migrate your [REP]({{glossary_reputation_token}}) during the [forking period]({{glossary_forking_period}}), there is no reward for that. However, if you staked your REP on the [forking market]({{glossary_forking_market}})'s outcome before the fork starts and the outcome you staked on becomes the [final outcome]({{glossary_final_outcome}}) of the forking market, you will receive a 40% [ROI]({{glossary_roi}}) on your stake in the [winning universe]({{glossary_winning_universe}}).
 
-In other words, you must migirate your REP within 60 days after a fork starts, but it is not necessarily to migrate it during the forking period. The forking period ends when the forking market enters the [finalized state]({{glossary_finalized_market}}), it can take less than 60 days. While, the period which you can migrate your REP is always fixed 60 days.
-
-{% capture image_src %}{{ "/" | absolute_url }}assets/images/{{page.collection}}/fork/to-dos/forking-period.svg{% endcapture %}
-{% include zoom-image.html src=image_src caption="Figure 2. forking period and migratable period" %}
+In other words, there is possibility only for the REP participated in a [dispute]({{glossary_dispute}}) to receive a 40% ROI. The REP migrated during the forking period cannot receive any reward, even if the child universe which the REP migrated to is the winning universe.


### PR DESCRIPTION
Summary of changes:
- You don't have to convert REPv1 to REPv2 before a fork starts, you just have to do it before the fork ends. (https://github.com/msagansk/Augur.Guide/pull/34#discussion_r557015582)
- There is no reward for migrating REP to a child universe. (https://github.com/msagansk/Augur.Guide/pull/34#discussion_r557018407)

@MicahZoltu Could you review this pull request?