### PR TITLE
[glossary] Add headers without body

### DIFF
--- a/_data/version2-english/glossary.yml
+++ b/_data/version2-english/glossary.yml
@@ -1,5 +1,65 @@
-Forecast Foundation         : A group of Augur developers. The members of this group are purely developers, not owners of Augur. They write the source of Augur and publish on <a href="https://github.com/AugurProject" target="_blank">Github</a>. Check the <a href="https://forecastfoundation.org/" target="_blank">official site</a> for details.
-
-Reputation token            : <i>under construction</i>
-
-smarty-pants                : A role name in the <a href="https://invite.augur.net" target="_blank">Augur Discord server</a> or the people who have the role. This role is given to the people who have shown a deep knowledge and interest in Augur. They have moderation privileges in the Augur Discord server. They do what they want to do, such as a moderate, help out, or just chat without any obligation nor reward. The addition of a member is decided by consultation within the members who already hold this role. They manage the ENS domain <code>augur2.eth</code> where Augur UI is registered (<a href="/version2-english/8-augur-ui.html#augur2eth" target="_blank">Click</a> for details).
+All Theoretical REP: <i>under construction</i>
+Child Universe: <i>under construction</i>
+Creation Bond: <i>under construction</i>
+Creator Fee: <i>under construction</i>
+Designated Reporter: <i>under construction</i>
+Designated Reporter Bond: <i>under construction</i>
+Designated Reporting: <i>under construction</i>
+Designated Reporting Phase: <i>under construction</i>
+Dispute: <i>under construction</i>
+Dispute Bond: <i>under construction</i>
+Dispute Round: <i>under construction</i>
+Dispute Round Phase: <i>under construction</i>
+Dispute Stake: <i>under construction</i>
+Dispute Window: <i>under construction</i>
+End Time: <i>under construction</i>
+Fee Window: <i>under construction</i>
+Final Outcome: <i>under construction</i>
+Finalized Market: <i>under construction</i>
+First Public Report: <i>under construction</i>
+First Public Reporter: <i>under construction</i>
+First Public Reporter Stake: <i>under construction</i>
+Forecast Foundation: A group of Augur developers. The members of this group are purely developers, not owners of Augur. They write the source of Augur and publish on <a href="https://github.com/AugurProject" target="_blank">Github</a>. Check the <a href="https://forecastfoundation.org/" target="_blank">official site</a> for details.
+Fork: <i>under construction</i>
+Forked Market: <i>under construction</i>
+Forking Market: <i>under construction</i>
+Forking Period: <i>under construction</i>
+Initial Report: <i>under construction</i>
+Initial Reporter: <i>under construction</i>
+Initial Report Bond: <i>under construction</i>
+Invalid Outcome: <i>under construction</i>
+Locked Universe: <i>under construction</i>
+Losing Universe: <i>under construction</i>
+Lying Universe: <i>under construction</i>
+Market: <i>under construction</i>
+Market Creator: <i>under construction</i>
+No-show Bond: <i>under construction</i>
+Non-Finalized Market: <i>under construction</i>
+Open Interest: <i>under construction</i>
+Open Reporting Phase: <i>under construction</i>
+Outcome: <i>under construction</i>
+Parent Universe: <i>under construction</i>
+Participation Token: <i>under construction</i>
+REP Bond: <i>under construction</i>
+REPv1: <i>under construction</i>
+REPv2: <i>under construction</i>
+ROI: <i>under construction</i>
+Report: <i>under construction</i>
+Reporter: <i>under construction</i>
+Reporting Fee: <i>under construction</i>
+Reporting Fee Pool: <i>under construction</i>
+Reputation Token: <i>under construction</i>
+Smart Contract: <i>under construction</i>
+Settlement: <i>under construction</i>
+Share: <i>under construction</i>
+Sibling Universe: <i>under construction</i>
+Smarty-pants: A role name in the <a href="https://invite.augur.net" target="_blank">Augur Discord server</a> or the people who have the role. This role is given to the people who have shown a deep knowledge and interest in Augur. They have moderation privileges in the Augur Discord server. They do what they want to do, such as a moderate, help out, or just chat without any obligation nor reward. The addition of a member is decided by consultation within the members who already hold this role. They manage the ENS domain <code>augur2.eth</code> where Augur UI is registered (<a href="/version2-english/8-augur-ui.html#augur2eth" target="_blank">Click</a> for details).
+Tentative Outcome: <i>under construction</i>
+Trading Fee: <i>under construction</i>
+Transaction Fee: <i>under construction</i>
+Truth Universe: <i>under construction</i>
+Unfilled Order: <i>under construction</i>
+Universe: <i>under construction</i>
+Validity Bond: <i>under construction</i>
+Waiting For Window Phase: <i>under construction</i>
+Winning Universe: <i>under construction</i>


### PR DESCRIPTION
I added headers to `_data/version2-english/glossary.yml`.
And I capitalized the first letter of `smarty-pants`. Because the sort of Jekyll is case-sensitive.